### PR TITLE
Battery controller update

### DIFF
--- a/battery_controller.py
+++ b/battery_controller.py
@@ -38,7 +38,7 @@ class BatteryController(control.controller.const_control.ConstControl):
     voltage_violations = 0
     violated_buses = set()
     
-    def __init__(self, net, element, variable, element_index, batteries, data_source=None,
+    def __init__(self, net, element, variable, element_index, batteries, data_source=None, second_ds=None,
                  in_service=True, recycle=False, order=0, level=0, **kwargs):
         super().__init__(net, in_service=in_service, recycle=recycle, data_source=data_source,
                          element_index=element_index, order=order, level=level,
@@ -54,6 +54,7 @@ class BatteryController(control.controller.const_control.ConstControl):
         self.prepare_net_status(net)
         self.register_for_batteries()
         self.activate_controlling = False
+        self.second_ds = second_ds
         
     
     def activate_contolling(self):
@@ -91,12 +92,25 @@ class BatteryController(control.controller.const_control.ConstControl):
                     #pass
         
         # die normale time_step ausführen
-        super().time_step(net, time)
+        #super().time_step(net, time)
+        self.values = self.data_source.get_time_step_value(time, self.profile_name)
+        self.write_with_loc(net, time)
         self.check_violations(net, time)
     
     
-    def write_with_loc(self, net):
+    def write_with_loc(self, net, time):
+        # erstmal die Werte zu dem timestep aus der Datasource vom ConstController
+        # der Ps holen (dann barucht man diesen Controller auch nicht mehr)
+        # => dann die Werte an dieselbe Stelle schreiben, wo gleich darauf die
+        # Werte aus der eigenen DataSource reinkommen
+        sds_values = self.second_ds.get_time_step_value(time, net.load.index)
+        self.values += sds_values
+        #net[self.element].loc[net.load.index, self.variable] = sds_values
         net[self.element].loc[self.element_index, self.variable] += self.values
+        print('\nmeine eigenen write_with_loc führt gerade aus!!')
+        if time == 95:
+            print('\nDatentyp von values:', self.values)
+            print('\nDatentype von sds_values:', sds_values)
         
         
     def check_violations(self, net, time):

--- a/kerber_timeseries_v04.py
+++ b/kerber_timeseries_v04.py
@@ -67,7 +67,7 @@ near_trafo = False
 controlling = False
 
 # wie hoch ist der PowerFactor der Haushalte?
-cosphi = 0.9
+cosphi = 0.90
 
 #Regelparameter für die Ladesäule einstellen
 ControllableBattery.set_control_params('Ki', 0.5)
@@ -78,7 +78,7 @@ ControllableBattery.set_control_params('Kd', 0.1)
 net = pn.create_kerber_vorstadtnetz_kabel_1()
 
 #### Szenario erzeugen #######################################################
-fun_scenario = Scenario.load_scenario('Szenario30')
+fun_scenario = Scenario.load_scenario('Szenario100')
 fun_scenario.set_resolution(resolution)
 
 if same_arrival:
@@ -125,20 +125,23 @@ loads_bat = DFData(datasource_bat)
 
 # controler erzeugen, der die Werte der loads zu den jeweiligen Zeitpukten
 # entsprechend loads setzt
-load_controler = control.ConstControl(net, element='load', variable='p_mw',
-                                      element_index=net.load.index,
-                                      data_source=loads,
-                                      profile_name=net.load.index)
+#load_controler = control.ConstControl(net, element='load', variable='p_mw',
+                                      #element_index=net.load.index,
+                                      #data_source=loads,
+                                      #profile_name=net.load.index,
+                                      #order=0, level=0)
 
 load_controler_q = control.ConstControl(net, element='load', variable='q_mvar',
                                       element_index=net.load.index,
                                       data_source=loads_q,
-                                      profile_name=net.load.index,)
+                                      profile_name=net.load.index,
+                                      order=1, level=1)
 
 load_controller_bat = BatteryController(net, element='load', variable='p_mw',
                                         element_index=datasource_bat.columns,#loading_data.columns,
                                         data_source=loads_bat, batteries=batteries,
-                                        order=1, level=1)
+                                        order=2, level=2,
+                                        second_ds=loads)
 
 if controlling:
     load_controller_bat.activate_contolling()

--- a/kerber_timeseries_v04.py
+++ b/kerber_timeseries_v04.py
@@ -8,6 +8,10 @@ kann es sein, dass bei den drei controllern irgendwelche überschneidungen beim
 Eintragen der einzelnen Werte aus ihrem jeweilgen datasource in die loads vom net
 gibt? nicht jeder Knoten hat im net[res_bus] eine Leistung anliegen (???)
 =>vielleicht am level etwas ändern vom BatteryController?
+FEHLER ENTDECKT: in battery_controller wird in timestep() am Ende
+super().timestep() aufgerufen, was dazu führt, dass die write_with_loc() vom
+normlen ConstController aufgerufen wird, statt unsere eigene write_with_loc vom
+BatteryController.
 
 ----------------------------------------
 bei Ladesäulen mit 22kW steigt die Leistung weiter nach dem Einschalten
@@ -42,17 +46,17 @@ from battery_controller import BatteryController
 from controllable_battery import ControllableBattery
 
 #### zeitliche Auflösung der Simulation ######################################
-resolution = '1min'
+resolution = '15min'
 
 #### Variablen zum Steuern der simulierten Szenarien #########################
 # Ankunftszeit (in Viertelstunden => 0800 wäre 32)
-same_arrival = True
+same_arrival = False
 arrival_time = 46
 
-same_power = True
+same_power = False
 loading_power = 11.1
 
-same_travelled = True
+same_travelled = False
 distance_travelled = 200
 
 # macht nur Sinn, einen der beiden auf True zu setzen
@@ -60,7 +64,7 @@ far_from_trafo = False
 near_trafo = False
 
 # soll geregelt werden?
-controlling = True
+controlling = False
 
 # wie hoch ist der PowerFactor der Haushalte?
 cosphi = 0.9
@@ -74,7 +78,7 @@ ControllableBattery.set_control_params('Kd', 0.1)
 net = pn.create_kerber_vorstadtnetz_kabel_1()
 
 #### Szenario erzeugen #######################################################
-fun_scenario = Scenario.load_scenario('Szenario100')
+fun_scenario = Scenario.load_scenario('Szenario30')
 fun_scenario.set_resolution(resolution)
 
 if same_arrival:
@@ -129,11 +133,12 @@ load_controler = control.ConstControl(net, element='load', variable='p_mw',
 load_controler_q = control.ConstControl(net, element='load', variable='q_mvar',
                                       element_index=net.load.index,
                                       data_source=loads_q,
-                                      profile_name=net.load.index)
+                                      profile_name=net.load.index,)
 
 load_controller_bat = BatteryController(net, element='load', variable='p_mw',
                                         element_index=datasource_bat.columns,#loading_data.columns,
-                                        data_source=loads_bat, batteries=batteries)
+                                        data_source=loads_bat, batteries=batteries,
+                                        order=1, level=1)
 
 if controlling:
     load_controller_bat.activate_contolling()

--- a/pptools.py
+++ b/pptools.py
@@ -94,9 +94,14 @@ def prepare_batteries(net, scenario, resolution):
                                   resolution=resolution)
         batteries.append(bat)
         
-    columns = scenario.scenario_data['load nr.'].astype(int)
-    datasource = pd.DataFrame(index=list(range(int(24*60/resolution))), columns=columns)
-        
+    #columns = scenario.scenario_data['load nr.'].astype(int)
+    datasource = pd.DataFrame(index=list(range(int(24*60/resolution))), columns=net.load.index)
+    # nur diejenigen Columns mit 0 füllen, die loads ohne ladesäule darstellen:
+    #for col in datasource.columns:
+        #if not col in columns:
+            #datasource.loc[:, col] = 0.0
+            
+    datasource.fillna(0.0, inplace=True) 
     return batteries, datasource # müssen an BatteryControler übergeben werden
 
 


### PR DESCRIPTION
Der `ConstControl`, der früher die Werte der SLPs für jede load ins net geschrieben hat, ist jetzt überflüssig. Das macht jetzt der `BatteryController` mit (dafür erwartet der jetzt noch ein zusätzliches Argument `second_ds`, welches die DataSource darstellt, die früher der `ConstControl` bekommen hätte). Damit das klappt, ist in `pptools` die Funktion `prepare_batteries` umgeschrieben worden, so dass auch die DataSource der Batteries immer 146 Spalten hat (so wie die DataSource der SLPs). Somit können in `write_with_loc` im `BatteryController` die values beider Datasources aufaddiert werden.